### PR TITLE
Update get_wq_metadata

### DIFF
--- a/R/get_wq_data.R
+++ b/R/get_wq_data.R
@@ -11,7 +11,7 @@
 #' @export
 #'
 #' @examples
-#' get_wq_data(locations = "G722", parameters = "25",
+#' get_wq_data(locations = "G722", parameters = "PHOSPHATE, TOTAL AS P",
 #'             startDate = "2020-01-01", endDate = "2024-01-01")
 get_wq_data <- function(..., timeseriesIds = NULL, startDate = NULL, endDate = NULL) {
   query <- create_wq_query(...)

--- a/R/get_wq_metadata.R
+++ b/R/get_wq_metadata.R
@@ -57,7 +57,7 @@ create_wq_query <- function (locations = "ALL", location_type = "STATION", param
 #' @export
 #'
 #' @examples
-#' get_wq_metadata(locations = c("G722", "BB52"), parameters = c("18", "25"),
+#' get_wq_metadata(locations = c("G722", "BB52"), parameters = c("NITRATE+NITRITE-N", "PHOSPHATE, TOTAL AS P"),
 #'                 startDate = "20190101", endDate = "20191231")
 get_wq_metadata <- function (..., startDate = NULL, endDate = NULL, offset = 0, limit = 1000, sleep = 1) {
   query <- create_wq_query(...)

--- a/R/get_wq_metadata.R
+++ b/R/get_wq_metadata.R
@@ -77,9 +77,7 @@ get_wq_metadata <- function (..., startDate = NULL, endDate = NULL, offset = 0, 
 
   results <- as_tibble(body$results)
   results[["startDate"]] <- lubridate::mdy(results[["startDate"]])
-  results[["startDateTime"]] <- as.POSIXct(results[["startDateTime"]] / 1000)
   results[["endDate"]] <- lubridate::mdy(results[["endDate"]])
-  results[["endDateTime"]] <- as.POSIXct(results[["endDateTime"]] / 1000)
 
   remaining <- body$totalRecords - offset - nrow(results)
   if (remaining > 0) {

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ ts <- get_timeseries_data(dbkeys = "91510", startDate = "20200101", endDate = "2
 wq_filters <- get_wq_filters()
 wq_filters$parameter
 
-get_wq_metadata(parameters = "25", startDate = "20190101", endDate = "20191231")
+get_wq_metadata(locations = c("G722", "BB52"), parameters = c("NITRATE+NITRITE-N", "PHOSPHATE, TOTAL AS P"), startDate = "20190101", endDate = "20191231")
 
-get_wq_data(locations = c("G722", "BB52"), parameters = c("18", "25"), startDate = "20190101", endDate = "20241231")
+get_wq_data(locations = "G722", parameters = "PHOSPHATE, TOTAL AS P", startDate = "2020-01-01", endDate = "2024-01-01")
 ```
 
 Reference Tables: https://insightsdata.sfwmd.gov/#/reference-tables

--- a/man/get_wq_data.Rd
+++ b/man/get_wq_data.Rd
@@ -22,6 +22,6 @@ A tibble of water quality values (NULL if no data found)
 Retrieves water quality data based on specified filters and date range.
 }
 \examples{
-get_wq_data(locations = "G722", parameters = "25",
+get_wq_data(locations = "G722", parameters = "PHOSPHATE, TOTAL AS P",
             startDate = "2020-01-01", endDate = "2024-01-01")
 }

--- a/man/get_wq_metadata.Rd
+++ b/man/get_wq_metadata.Rd
@@ -33,6 +33,6 @@ A tibble containing water quality metadata
 Retrieves metadata for water quality measurements based on specified filters.
 }
 \examples{
-get_wq_metadata(locations = c("G722", "BB52"), parameters = c("18", "25"),
+get_wq_metadata(locations = c("G722", "BB52"), parameters = c("NITRATE+NITRITE-N", "PHOSPHATE, TOTAL AS P"),
                 startDate = "20190101", endDate = "20191231")
 }


### PR DESCRIPTION
Remove datetime parsing for columns that no longer exist in wq_metadata. Update get_wq_metadata and get_wq_data documentation examples (and README) to show parameter names, not codes.